### PR TITLE
Support tracking the ratio stats

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.metallicgoat</groupId>
     <artifactId>MBLeaderboards</artifactId>
-    <version>1.1.3</version>
+    <version>1.1.5</version>
 
     <repositories>
         <repository>
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.8.8-R0.1-SNAPSHOT</version>
+            <version>1.12.2-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -39,13 +39,13 @@
         <dependency>
             <groupId>de.marcely.bedwars</groupId>
             <artifactId>API</artifactId>
-            <version>5.4.14</version>
+            <version>5.5.5</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.34</version>
+            <version>1.18.42</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/me/metallicgoat/bedwarsleaderboards/periodicstats/CustomTrackedStatSet.java
+++ b/src/main/java/me/metallicgoat/bedwarsleaderboards/periodicstats/CustomTrackedStatSet.java
@@ -3,6 +3,7 @@ package me.metallicgoat.bedwarsleaderboards.periodicstats;
 import de.marcely.bedwars.api.arena.Arena;
 import de.marcely.bedwars.api.arena.picker.condition.ArenaConditionGroup;
 import de.marcely.bedwars.api.message.Message;
+import de.marcely.bedwars.api.player.DefaultPlayerStatSet;
 import de.marcely.bedwars.api.player.PlayerDataAPI;
 import de.marcely.bedwars.api.player.PlayerStatSet;
 import de.marcely.bedwars.api.player.PlayerStats;
@@ -13,6 +14,8 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.plugin.Plugin;
 
 public class CustomTrackedStatSet implements PlayerStatSet {
+
+  public static byte RATIO_OFFSET_DIGITS = 8;
 
   @Getter
   private final String id;
@@ -48,11 +51,20 @@ public class CustomTrackedStatSet implements PlayerStatSet {
 
   @Override
   public String getDisplayedValue(PlayerStats stats) {
-    return this.trackedStatSet.formatValue(stats.get(this.id));
+    return formatValue(stats.get(this.id));
   }
 
   @Override
   public String formatValue(Number value) {
+    if (isTrackingKD()) {
+      double kdRepresentation = value.doubleValue();
+
+      double kills = (int) kdRepresentation;
+      double deaths = (int) Math.round((kdRepresentation - kills) * Math.pow(10, RATIO_OFFSET_DIGITS));
+
+      value = kills / (deaths == 0 ? 1 : deaths);
+    }
+
     return this.trackedStatSet.formatValue(value);
   }
 
@@ -70,6 +82,10 @@ public class CustomTrackedStatSet implements PlayerStatSet {
 
     } else
       stats.set(this.id, value);
+  }
+
+  public boolean isTrackingKD() {
+    return this.trackedStatSet == DefaultPlayerStatSet.K_D;
   }
 
   public boolean isSupportedInArena(Arena arena) {

--- a/src/main/java/me/metallicgoat/bedwarsleaderboards/periodicstats/CustomTrackedStatSet.java
+++ b/src/main/java/me/metallicgoat/bedwarsleaderboards/periodicstats/CustomTrackedStatSet.java
@@ -15,7 +15,7 @@ import org.bukkit.plugin.Plugin;
 
 public class CustomTrackedStatSet implements PlayerStatSet {
 
-  public static byte RATIO_OFFSET_DIGITS = 8;
+  public static byte RATIO_OFFSET_DIGITS = 5;
 
   @Getter
   private final String id;

--- a/src/main/java/me/metallicgoat/bedwarsleaderboards/periodicstats/CustomTrackedStatSet.java
+++ b/src/main/java/me/metallicgoat/bedwarsleaderboards/periodicstats/CustomTrackedStatSet.java
@@ -56,11 +56,11 @@ public class CustomTrackedStatSet implements PlayerStatSet {
 
   @Override
   public String formatValue(Number value) {
-    if (isTrackingKD()) {
-      double kdRepresentation = value.doubleValue();
+    if (isTrackingRatioValue()) {
+      double ratioRepresentation = value.doubleValue();
 
-      double kills = (int) kdRepresentation;
-      double deaths = (int) Math.round((kdRepresentation - kills) * Math.pow(10, RATIO_OFFSET_DIGITS));
+      double kills = (int) ratioRepresentation;
+      double deaths = (int) Math.round((ratioRepresentation - kills) * Math.pow(10, RATIO_OFFSET_DIGITS));
 
       value = kills / (deaths == 0 ? 1 : deaths);
     }
@@ -84,8 +84,10 @@ public class CustomTrackedStatSet implements PlayerStatSet {
       stats.set(this.id, value);
   }
 
-  public boolean isTrackingKD() {
-    return this.trackedStatSet == DefaultPlayerStatSet.K_D;
+  public boolean isTrackingRatioValue() {
+    return this.trackedStatSet == DefaultPlayerStatSet.K_D ||
+        this.trackedStatSet == DefaultPlayerStatSet.FINAL_K_D ||
+        this.trackedStatSet == DefaultPlayerStatSet.W_L;
   }
 
   public boolean isSupportedInArena(Arena arena) {

--- a/src/main/java/me/metallicgoat/bedwarsleaderboards/periodicstats/PeriodicType.java
+++ b/src/main/java/me/metallicgoat/bedwarsleaderboards/periodicstats/PeriodicType.java
@@ -27,9 +27,7 @@ public enum PeriodicType {
         return lastReset.toLocalDate().isBefore(now.toLocalDate());
 
       case WEEKLY:
-        final ZonedDateTime lastTuesday = lastReset.with(TemporalAdjusters.previousOrSame(Config.resetDay));
-        final ZonedDateTime nextTuesday = lastTuesday.with(TemporalAdjusters.next(Config.resetDay));
-        return now.isEqual(nextTuesday) || now.isAfter(nextTuesday);
+        return now.getDayOfWeek() == Config.resetDay && lastReset.toLocalDate().isBefore(now.toLocalDate());
 
       case MONTHLY:
         return lastReset.getMonthValue() != now.getMonthValue() || lastReset.getYear() != now.getYear();

--- a/src/main/java/me/metallicgoat/bedwarsleaderboards/periodicstats/StatChangeListener.java
+++ b/src/main/java/me/metallicgoat/bedwarsleaderboards/periodicstats/StatChangeListener.java
@@ -3,6 +3,7 @@ package me.metallicgoat.bedwarsleaderboards.periodicstats;
 import de.marcely.bedwars.api.GameAPI;
 import de.marcely.bedwars.api.arena.Arena;
 import de.marcely.bedwars.api.event.player.PlayerStatChangeEvent;
+import de.marcely.bedwars.api.player.DefaultPlayerStatSet;
 import de.marcely.bedwars.api.player.PlayerStatSet;
 import de.marcely.bedwars.api.player.PlayerStats;
 import me.metallicgoat.bedwarsleaderboards.Config;
@@ -33,6 +34,21 @@ public class StatChangeListener implements Listener {
 
     // Update all custom stats
     for (CustomTrackedStatSet customStatSet : Config.customStatSets) {
+
+      // Extra tracking for the KD ratio
+      if (customStatSet.getTrackedStatSet() == DefaultPlayerStatSet.K_D) {
+
+        // int part represents kills, decimal part represents deaths
+        if (statSet == DefaultPlayerStatSet.KILLS) {
+          stats.add(customStatSet.getId(), change.doubleValue());
+
+        } else if (statSet == DefaultPlayerStatSet.DEATHS) {
+          stats.add(customStatSet.getId(), Math.pow(10, change.doubleValue() * -CustomTrackedStatSet.RATIO_OFFSET_DIGITS));
+        }
+
+        System.out.println(stats.get(customStatSet.getId()));
+      }
+
       if (customStatSet.getTrackedStatSet() == statSet && customStatSet.isSupportedInArena(arena)) {
         stats.add(customStatSet.getId(), change);
       }

--- a/src/main/java/me/metallicgoat/bedwarsleaderboards/periodicstats/StatChangeListener.java
+++ b/src/main/java/me/metallicgoat/bedwarsleaderboards/periodicstats/StatChangeListener.java
@@ -86,7 +86,7 @@ public class StatChangeListener implements Listener {
       stats.add(customStatSet.getId(), change.doubleValue());
 
     } else if (changingStatSet == denominator) {
-      stats.add(customStatSet.getId(), Math.pow(10, change.doubleValue() * -CustomTrackedStatSet.RATIO_OFFSET_DIGITS));
+      stats.add(customStatSet.getId(), change.doubleValue() * Math.pow(10, -CustomTrackedStatSet.RATIO_OFFSET_DIGITS));
     }
   }
 }

--- a/src/main/java/me/metallicgoat/bedwarsleaderboards/periodicstats/StatChangeListener.java
+++ b/src/main/java/me/metallicgoat/bedwarsleaderboards/periodicstats/StatChangeListener.java
@@ -35,22 +35,47 @@ public class StatChangeListener implements Listener {
     // Update all custom stats
     for (CustomTrackedStatSet customStatSet : Config.customStatSets) {
 
-      // Extra tracking for the KD ratio
-      if (customStatSet.getTrackedStatSet() == DefaultPlayerStatSet.K_D) {
-
-        // int part represents kills, decimal part represents deaths
-        if (statSet == DefaultPlayerStatSet.KILLS) {
-          stats.add(customStatSet.getId(), change.doubleValue());
-
-        } else if (statSet == DefaultPlayerStatSet.DEATHS) {
-          stats.add(customStatSet.getId(), Math.pow(10, change.doubleValue() * -CustomTrackedStatSet.RATIO_OFFSET_DIGITS));
-        }
-
-        System.out.println(stats.get(customStatSet.getId()));
-      }
+      updateRatios(stats, statSet, customStatSet, change);
 
       if (customStatSet.getTrackedStatSet() == statSet && customStatSet.isSupportedInArena(arena)) {
         stats.add(customStatSet.getId(), change);
+      }
+    }
+  }
+
+
+  // Extra tracking for the ratios
+  private void updateRatios(PlayerStats stats, PlayerStatSet statSet, CustomTrackedStatSet customStatSet, Number change) {
+    if (customStatSet.getTrackedStatSet() == DefaultPlayerStatSet.K_D) {
+
+      // int part represents kills, decimal part represents deaths
+      if (statSet == DefaultPlayerStatSet.KILLS) {
+        stats.add(customStatSet.getId(), change.doubleValue());
+
+      } else if (statSet == DefaultPlayerStatSet.DEATHS) {
+        stats.add(customStatSet.getId(), Math.pow(10, change.doubleValue() * -CustomTrackedStatSet.RATIO_OFFSET_DIGITS));
+      }
+    }
+
+    if (customStatSet.getTrackedStatSet() == DefaultPlayerStatSet.FINAL_K_D) {
+
+      // int part represents final kills, decimal part represents final deaths
+      if (statSet == DefaultPlayerStatSet.FINAL_KILLS) {
+        stats.add(customStatSet.getId(), change.doubleValue());
+
+      } else if (statSet == DefaultPlayerStatSet.FINAL_DEATHS) {
+        stats.add(customStatSet.getId(), Math.pow(10, change.doubleValue() * -CustomTrackedStatSet.RATIO_OFFSET_DIGITS));
+      }
+    }
+
+    if (customStatSet.getTrackedStatSet() == DefaultPlayerStatSet.W_L) {
+
+      // int part represents wins, decimal part represents loses
+      if (statSet == DefaultPlayerStatSet.WINS) {
+        stats.add(customStatSet.getId(), change.doubleValue());
+
+      } else if (statSet == DefaultPlayerStatSet.LOSES) {
+        stats.add(customStatSet.getId(), Math.pow(10, change.doubleValue() * -CustomTrackedStatSet.RATIO_OFFSET_DIGITS));
       }
     }
   }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: MBLeaderboardsAddon
-version: 1.1.3
+version: 1.1.5
 author: MetallicGoat
 main: me.metallicgoat.bedwarsleaderboards.LeaderboardsPlugin
 description: Adds leaderboards placeholders to MBedwars


### PR DESCRIPTION
Kinda hacky. We need to track the deaths and kills across the peroid to get this ratio. Using integer part of the double to track kills, and decimal part to track deaths